### PR TITLE
Strip now-redundant bSoEReset/fbSoEReset/axisRef from FB_AxisControl

### DIFF
--- a/HalfBROT/HalfBROT/POUs/FB_AxisControl.TcPOU
+++ b/HalfBROT/HalfBROT/POUs/FB_AxisControl.TcPOU
@@ -6,7 +6,6 @@ VAR_INPUT
 	bMoveAxis				: BOOL;		// Move azimuth to given position
 	bTracking				: BOOL;		// enable tracking
 	bStopAxis				: BOOL;		// stop the Axis
-	bSoEReset				: BOOL;		// diagnostic reset
 	fMinPosition			: REAL := 0;
 	fMaxPosition			: REAL := 450.0;
 	fCalibPosition			: LREAL := 45.0; // // current position of the calibration cam
@@ -15,16 +14,14 @@ VAR_OUTPUT
 END_VAR
 VAR
 	fSlewTime				: LREAL;	// time to reach target position
-	
+
 	InDigitalInputs	  AT%I*	: WORD;		// digitale inputs der Endlagen
 	InDiagnostic	  AT%I*	: UDINT;	// diagnostic number
 	InTorque	 	  AT%I*	: INT;		// derotator torque feedback
 	IbSTO		  	  AT%I*	: BOOL;		// STO
-	axisRef					: AXIS_REF;	
-	
+
 	fbAxisCalibration		: MC_SetPosition;
 
-	fbSoEReset			  :	FB_SoEReset;
 	axisEvent			: FB_EventLog;
 	diagnosticEvent		: FB_EventLog;
 	


### PR DESCRIPTION
## Summary
- Removes the local `bSoEReset` (VAR_INPUT), `fbSoEReset`, and `axisRef` declarations from `FB_AxisControl`
- These existed here as a workaround for BROTLib's `FB_BaseAxis` previously lacking them (see BROTLib's `FB_Axis.md` unification plan)
- BROTLib's `FB_BaseAxis` now declares all three itself, so keeping local copies here would collide with the inherited members once this repo picks up the updated BROTLib library

## Dependency
Requires BROTLib's [`feature/fb-axis-unification`](https://github.com/BROTLib/BROTLib/pull/1) to be merged/released and the updated BROTLib library installed locally before this compiles - HalfBROT references BROTLib as an installed library, not a live source reference.

Usages elsewhere (`FB_AzimuthControl`, `FB_ElevationControl`, `FB_DerotatorControl`) are unaffected since they reference these members by name, not by declaring class.

## Test plan
- [x] Rebuilt cleanly in TwinCAT XAE (Release|TwinCAT RT (x64)): 0 errors, 2 pre-existing warnings unrelated to this change (ambiguous VISUSYMBOLS namespace)
- [ ] Re-verify once BROTLib PR #1 is merged and the library reinstalled locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)